### PR TITLE
feat: validate method signatures

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <description>RPC for Vaadin TestBench</description>
 
     <properties>
-        <vaadin.version>14.8.11</vaadin.version>
+        <vaadin.version>14.10.1</vaadin.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-testbench-core</artifactId>
-            <version>6.4.0</version>             
+            <version>6.5.1</version>             
             <scope>compile</scope>
         </dependency>
         

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.flowingcode.vaadin.test</groupId>
     <artifactId>testbench-rpc</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <name>RPC for Vaadin TestBench</name>
     <description>RPC for Vaadin TestBench</description>
 

--- a/src/main/java/com/flowingcode/vaadin/testbench/rpc/HasRpcSupport.java
+++ b/src/main/java/com/flowingcode/vaadin/testbench/rpc/HasRpcSupport.java
@@ -23,6 +23,7 @@ import com.vaadin.flow.component.ClientCallable;
 import com.vaadin.testbench.HasDriver;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.Proxy;
 import java.util.List;
 import java.util.Map;
@@ -88,6 +89,15 @@ public interface HasRpcSupport extends HasDriver {
    * #call}.
    */
   default <T> T createCallableProxy(Class<T> intf) {
+    if (!intf.isInterface()) {
+      throw new IllegalArgumentException(intf.getName() + " is not an interface");
+    }
+    for (Method method : intf.getMethods()) {
+      if (!Modifier.isStatic(method.getModifiers())) {
+        TypeConversion.checkMethod(method);
+      }
+    }
+
     return intf.cast(
         Proxy.newProxyInstance(
             intf.getClassLoader(),

--- a/src/main/java/com/flowingcode/vaadin/testbench/rpc/IllegalRpcSignatureException.java
+++ b/src/main/java/com/flowingcode/vaadin/testbench/rpc/IllegalRpcSignatureException.java
@@ -1,0 +1,9 @@
+package com.flowingcode.vaadin.testbench.rpc;
+
+public class IllegalRpcSignatureException extends RpcException {
+
+  protected IllegalRpcSignatureException(String message) {
+    super(message);
+  }
+
+}

--- a/src/main/java/com/flowingcode/vaadin/testbench/rpc/RpcException.java
+++ b/src/main/java/com/flowingcode/vaadin/testbench/rpc/RpcException.java
@@ -25,6 +25,10 @@ import java.util.stream.Stream;
 
 public class RpcException extends RuntimeException {
 
+  protected RpcException(String message) {
+    super(message);
+  }
+
   public RpcException(String method, Object[] arguments, String message) {
     super(makeMessage(method, arguments, message));
   }

--- a/src/main/java/com/flowingcode/vaadin/testbench/rpc/TypeConversion.java
+++ b/src/main/java/com/flowingcode/vaadin/testbench/rpc/TypeConversion.java
@@ -1,5 +1,7 @@
 package com.flowingcode.vaadin.testbench.rpc;
 
+import elemental.json.JsonValue;
+import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.math.BigInteger;
@@ -40,6 +42,46 @@ class TypeConversion {
           .collect(Collectors.toList());
     }
     return JsonArrayList.wrapForTestbench(value);
+  }
+
+  private boolean isValidType(Class<?> type) {
+    return type==void.class
+        || type == boolean.class
+        || type == int.class
+        || type == double.class
+        || type == Boolean.class
+        || type == Integer.class
+        || type == Double.class
+        || type == String.class
+        || type == JsonValue.class;
+  }
+
+  static void checkMethod(Method method) {
+
+    for (Class<?> type : method.getParameterTypes()) {
+      if (!type.isEnum() && !isValidType(type)) {
+        throw new IllegalRpcSignatureException(String
+            .format("Argument of type %s is not supported by TestBench-RPC.", type.getName()));
+      }
+    }
+
+    if (method.getReturnType()==JsonArrayList.class) {
+      Type returnType = method.getGenericReturnType();
+      if (returnType instanceof ParameterizedType) {
+        Type elementType = ((ParameterizedType) returnType).getActualTypeArguments()[0];
+        if (elementType == Long.class || elementType == long.class
+            || elementType instanceof Class && isValidType((Class<?>) elementType)) {
+          return;
+        }
+      }
+      throw new IllegalRpcSignatureException(
+          String.format("Return type %s is not supported by TestBench-RPC.", returnType));
+    }
+
+    if (!isValidType(method.getReturnType())) {
+      throw new IllegalRpcSignatureException(String
+          .format("Return type %s is not supported by TestBench-RPC.", method.getReturnType()));
+    }
   }
 
 }

--- a/src/test/java/com/flowingcode/vaadin/testbench/rpc/integration/TestWrongSignatures.java
+++ b/src/test/java/com/flowingcode/vaadin/testbench/rpc/integration/TestWrongSignatures.java
@@ -1,0 +1,99 @@
+package com.flowingcode.vaadin.testbench.rpc.integration;
+
+import com.flowingcode.vaadin.testbench.rpc.HasRpcSupport;
+import com.flowingcode.vaadin.testbench.rpc.IllegalRpcSignatureException;
+import java.util.List;
+import org.junit.Test;
+import org.openqa.selenium.WebDriver;
+
+// Test several callable interfaces with unsupported parameter or return types
+public class TestWrongSignatures implements HasRpcSupport {
+
+  interface WrongSignature_PrimitiveLongArgument {
+    void foo(long a);
+  }
+
+  interface WrongSignature_ObjectLongArgument {
+    void foo(Long a);
+  }
+
+  interface WrongSignature_ReturnPrimitiveLongArgument {
+    Long foo();
+  }
+
+  interface WrongSignature_ReturnObjectLongArgument {
+    Long foo();
+  }
+
+  interface WrongSignature_ReturnRawList {
+    @SuppressWarnings("rawtypes")
+    List foo();
+  }
+
+  interface WrongSignature_ReturnUnsupportedList {
+    List<Object> foo();
+  }
+
+  interface WrongSignature_ListArgument {
+    void foo(List<Integer> arg);
+  }
+
+  enum MyEnum {
+    A, B, C
+  }
+
+  interface WrongSignature_ReturnEnum {
+    MyEnum foo();
+  }
+
+  @Test
+  public void testIntegrationViewCallables() {
+    createCallableProxy(IntegrationViewCallables.class);
+  }
+
+  @Test(expected = IllegalRpcSignatureException.class)
+  public void testPrimitiveLongArgument() {
+    createCallableProxy(WrongSignature_PrimitiveLongArgument.class);
+  }
+
+  @Test(expected = IllegalRpcSignatureException.class)
+  public void testObjectLongArgument() {
+    createCallableProxy(WrongSignature_ObjectLongArgument.class);
+  }
+
+  @Test(expected = IllegalRpcSignatureException.class)
+  public void testReturnPrimitiveLongArgument() {
+    createCallableProxy(WrongSignature_ReturnPrimitiveLongArgument.class);
+  }
+
+  @Test(expected = IllegalRpcSignatureException.class)
+  public void testReturnObjectLongArgument() {
+    createCallableProxy(WrongSignature_ReturnObjectLongArgument.class);
+  }
+
+  @Test(expected = IllegalRpcSignatureException.class)
+  public void testReturnRawList() {
+    createCallableProxy(WrongSignature_ReturnRawList.class);
+  }
+
+  @Test(expected = IllegalRpcSignatureException.class)
+  public void testReturnUnsupportedList() {
+    createCallableProxy(WrongSignature_ReturnUnsupportedList.class);
+  }
+
+  @Test(expected = IllegalRpcSignatureException.class)
+  public void testReturnEnum() {
+    createCallableProxy(WrongSignature_ReturnEnum.class);
+  }
+
+  @Test(expected = IllegalRpcSignatureException.class)
+  public void testListArgument() {
+    createCallableProxy(WrongSignature_ListArgument.class);
+  }
+
+  @Override
+  public WebDriver getDriver() {
+    throw new UnsupportedOperationException();
+  }
+
+}


### PR DESCRIPTION
Validate that argument and return types used in callable interfaces are actually supported.