### PR TITLE
fix: support JsonObject

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,7 @@ public class SampleIT extends AbstractViewTest implements HasRpcSupport {
 
 ### Argument and return types
 
-Types `boolean`, `int`, `double`, their boxed types (`Boolean`, `Integer` and `Double`), `String` and `JsonValue` are supported as both argument and return types in `@ClientCallable` methods. Actual parameters of type `JsonObject` are not supported.
-Enumeration types are supported as arguments, but not as return types.
+Types `boolean`, `int`, `double`, their boxed types (`Boolean`, `Integer` and `Double`), `String` and `JsonValue` are supported as both argument and return types in `@ClientCallable` methods. Enumeration types are supported as arguments, but not as return types.
 
 **Returning Lists** The return type of a `@ClientCallable` method can be declared as `JsonArrayList<T>` (where the element type `T` is a supported return type, or `Long`).
 In TestBench side, the `JsonArrayList` will implement `Collection<T>`, which facilitates asserting its value (for instance, with hamcrest matchers).

--- a/src/main/java/com/flowingcode/vaadin/testbench/rpc/TypeConversion.java
+++ b/src/main/java/com/flowingcode/vaadin/testbench/rpc/TypeConversion.java
@@ -10,6 +10,7 @@ import java.lang.reflect.Type;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.experimental.UtilityClass;
 import org.apache.commons.lang3.reflect.TypeUtils;
@@ -43,7 +44,8 @@ class TypeConversion {
         value.getClass().getName(), returnType.getName()));
   }
 
-  private static JsonValue toJsonValue(Object arg) {
+  @SuppressWarnings("unchecked")
+  static JsonValue toJsonValue(Object arg) {
     if (arg == null) {
       return Json.createNull();
     }
@@ -66,6 +68,11 @@ class TypeConversion {
         array.set(array.length(), toJsonValue(e));
       }
       return array;
+    }
+    if (arg instanceof Map) {
+      JsonObject object = Json.createObject();
+      ((Map<String, Object>) arg).forEach((k, v) -> object.put(k, toJsonValue(v)));
+      return object;
     }
     throw new ClassCastException(String.format("Cannot cast %s as %s",
         arg.getClass().getName(), JsonValue.class));
@@ -112,7 +119,7 @@ class TypeConversion {
         || type == Integer.class
         || type == Double.class
         || type == String.class
-        || JsonValue.class.isAssignableFrom(type) && !JsonObject.class.isAssignableFrom(type);
+        || JsonValue.class.isAssignableFrom(type);
   }
 
   static void checkMethod(Method method) {

--- a/src/test/java/com/flowingcode/vaadin/testbench/rpc/integration/IntegrationView.java
+++ b/src/test/java/com/flowingcode/vaadin/testbench/rpc/integration/IntegrationView.java
@@ -31,6 +31,7 @@ import elemental.json.JsonArray;
 import elemental.json.JsonBoolean;
 import elemental.json.JsonNull;
 import elemental.json.JsonNumber;
+import elemental.json.JsonObject;
 import elemental.json.JsonString;
 import elemental.json.JsonType;
 import elemental.json.JsonValue;
@@ -251,4 +252,31 @@ public class IntegrationView extends Div implements IntegrationViewCallables {
     return Json.createArray();
   }
 
+  @Override
+  @ClientCallable
+  public JsonObject returnJsonObject(String key, String value) {
+    JsonObject obj = Json.createObject();
+    obj.put(key, value);
+    return obj;
+  }
+
+  @Override
+  @ClientCallable
+  public JsonValue returnJsonValueJsonObject(String key, String value) {
+    JsonObject obj = Json.createObject();
+    obj.put(key, value);
+    return obj;
+  }
+
+  @Override
+  @ClientCallable
+  public JsonValue readJsonObject(JsonObject obj, String key) {
+    return obj.get(key);
+  }
+
+  @Override
+  @ClientCallable
+  public boolean isPrototypeOf(String string) {
+    return true;
+  }
 }

--- a/src/test/java/com/flowingcode/vaadin/testbench/rpc/integration/IntegrationViewCallables.java
+++ b/src/test/java/com/flowingcode/vaadin/testbench/rpc/integration/IntegrationViewCallables.java
@@ -24,6 +24,7 @@ import elemental.json.JsonArray;
 import elemental.json.JsonBoolean;
 import elemental.json.JsonNull;
 import elemental.json.JsonNumber;
+import elemental.json.JsonObject;
 import elemental.json.JsonString;
 import elemental.json.JsonValue;
 
@@ -97,5 +98,13 @@ public interface IntegrationViewCallables {
   JsonArrayList<Integer> getIntegers();
 
   JsonArrayList<Long> getLongs();
+
+  JsonValue returnJsonValueJsonObject(String key, String value);
+
+  JsonObject returnJsonObject(String key, String value);
+
+  JsonValue readJsonObject(JsonObject obj, String key);
+
+  boolean isPrototypeOf(String string);
 
 }

--- a/src/test/java/com/flowingcode/vaadin/testbench/rpc/integration/IntegrationViewIT.java
+++ b/src/test/java/com/flowingcode/vaadin/testbench/rpc/integration/IntegrationViewIT.java
@@ -224,6 +224,13 @@ public class IntegrationViewIT extends AbstractViewTest implements HasRpcSupport
   }
 
   @Test
+  public void test11_returnJsonValueNullArray() {
+    JsonArray result = (JsonArray) $server.returnJsonValueNullArray();
+    assertEquals(JsonType.NULL, result.get(0).getType());
+    assertEquals(JsonType.NULL, result.get(1).getType());
+  }
+
+  @Test
   public void test10_returnJsonString() {
     JsonString result = $server.returnJsonString(HELLO);
     assertEquals(HELLO, result.asString());

--- a/src/test/java/com/flowingcode/vaadin/testbench/rpc/integration/IntegrationViewIT.java
+++ b/src/test/java/com/flowingcode/vaadin/testbench/rpc/integration/IntegrationViewIT.java
@@ -35,6 +35,7 @@ import elemental.json.JsonArray;
 import elemental.json.JsonBoolean;
 import elemental.json.JsonNull;
 import elemental.json.JsonNumber;
+import elemental.json.JsonObject;
 import elemental.json.JsonString;
 import elemental.json.JsonType;
 import elemental.json.JsonValue;
@@ -297,4 +298,26 @@ public class IntegrationViewIT extends AbstractViewTest implements HasRpcSupport
     assertEquals(value.getType(), JsonType.valueOf($server.testJsonValue(value)));
   }
 
+  @Test
+  public void test13_readJsonObject() {
+    JsonObject obj = Json.createObject();
+    obj.put("key", HELLO);
+    assertEquals(HELLO, $server.readJsonObject(obj, "key").asString());
+  }
+
+  @Test
+  public void test13_returnJsonObject() {
+    JsonObject obj = Json.createObject();
+    obj.put("key", HELLO);
+    JsonObject result = $server.returnJsonObject("key", HELLO);
+    assertEquals(HELLO, result.getString("key"));
+  }
+
+  @Test
+  public void test13_returnJsonValueJsonObject() {
+    JsonObject obj = Json.createObject();
+    obj.put("key", HELLO);
+    JsonObject result = (JsonObject) $server.returnJsonValueJsonObject("key", HELLO);
+    assertEquals(HELLO, result.getString("key"));
+  }
 }


### PR DESCRIPTION
In issue #7, I documented that "JsonObject is not supported." This limitation is as a particular case related to issues #3 and #4, which were not (fully) resolved in PR #5 and #6.

However, upon further investigation, it was found that implementing support for JsonObject is not as challenging as initially perceived. Therefore, I propose addressing this issue by adding support for JsonObject, as originally claimed in the documentation.

By incorporating this implementation, we can ensure that `JsonValue` is fully supported and can handle the specific case of `JsonObject`. This will provide a comprehensive solution for the related issues and improve the functionality of the project.

