### PR TITLE
Refactor HasRpcSupport

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.flowingcode.vaadin.test</groupId>
     <artifactId>testbench-rpc</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
     <name>RPC for Vaadin TestBench</name>
     <description>RPC for Vaadin TestBench</description>
 

--- a/src/main/java/com/flowingcode/vaadin/testbench/rpc/HasRpcSupport.java
+++ b/src/main/java/com/flowingcode/vaadin/testbench/rpc/HasRpcSupport.java
@@ -45,6 +45,26 @@ public interface HasRpcSupport extends HasDriver {
    * Create a TestBench proxy that invokes methods from the interface through a client call.
    */
   default <T> T createCallableProxy(Class<T> intf) {
+    return HasRpcSupport$companion.createCallableProxy(this, intf);
+  }
+
+
+  @Deprecated
+  default Object call(String callable, Object... arguments) {
+    try {
+      return HasRpcSupport$InvocationHandler.call(this, callable, arguments);
+    } catch (RpcCallException e) {
+      throw new RpcException(callable, arguments, e.getMessage());
+    }
+  }
+
+}
+
+
+class HasRpcSupport$companion {
+
+  static <T> T createCallableProxy(HasRpcSupport rpc, Class<T> intf) {
+
     if (!intf.isInterface()) {
       throw new IllegalArgumentException(intf.getName() + " is not an interface");
     }
@@ -55,16 +75,7 @@ public interface HasRpcSupport extends HasDriver {
     }
 
     return intf.cast(Proxy.newProxyInstance(intf.getClassLoader(), new Class<?>[] {intf},
-        new HasRpcSupport$InvocationHandler(this)));
-  }
-
-  @Deprecated
-  default Object call(String callable, Object... arguments) {
-    try {
-      return HasRpcSupport$InvocationHandler.call(this, callable, arguments);
-    } catch (RpcCallException e) {
-      throw new RpcException(callable, arguments, e.getMessage());
-    }
+        new HasRpcSupport$InvocationHandler(rpc)));
   }
 
 }


### PR DESCRIPTION
I've made some refactors in `HasRpcSupport` that aim to pave the way for an upcoming feature. Here's a summary of the changes:

- Moved the `InvocationHandler` implementation to a standalone class, separating it from its previous location.
- Transferred the `HasRpcSupport.call` method to the InvocationHandler, providing a more cohesive structure (there is no need to have `call` as a public method in `HasRpcSupport` because RPC calls are started by the invocation handler)
- Altered the exception handling to be handled by the caller, enhancing the control flow and error management.
- Created a companion class to handle the implementation of `createCallableProxy` (that would have been a private method in `HasRpcSupport` but for now we have tp support Java 8).
- Conducted refactoring on the InvocationHandler to improve its overall structure and readability.