### PR TITLE
feat: improve RMI error reporting

### DIFF
--- a/src/main/java/com/flowingcode/vaadin/testbench/rpc/RmiConstants.java
+++ b/src/main/java/com/flowingcode/vaadin/testbench/rpc/RmiConstants.java
@@ -43,8 +43,13 @@ class RmiConstants {
   /** Arguments of the invoked method. */
   static final String RMI_METHOD_ARGUMENTS = "methodArguments";
 
+  /** Marker indicating that a JsonObject is a RMI response. */
   static final String RMI_RESPONSE_MARKER = "marker";
 
+  /** Response data. */
   static final String RMI_RESPONSE_DATA = "data";
+
+  /** Response error code. */
+  static final String RMI_RESPONSE_ERROR = "error";
 
 }

--- a/src/main/java/com/flowingcode/vaadin/testbench/rpc/RmiError.java
+++ b/src/main/java/com/flowingcode/vaadin/testbench/rpc/RmiError.java
@@ -1,0 +1,54 @@
+package com.flowingcode.vaadin.testbench.rpc;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.Accessors;
+
+/**
+ * Error codes related to RMI for Vaadin TestBench.
+ *
+ * @author Javier Godoy / Flowing Code
+ */
+@RequiredArgsConstructor
+enum RmiError {
+
+  /** An invalid request was received. */
+  E_PROTOCOL_ERROR(true),
+
+  /** The requested target class cannot be located. */
+  E_CLASS_NOT_FOUND(false),
+
+  /** The requested class does not implement the requested method. */
+  E_NO_SUCH_METHOD(false),
+
+  /** Attempt to pass an unregistered value as an object reference. */
+  E_OBJECT_NOT_EXIST(false),
+
+  /**
+   * An exception ocurred when executing the remote method.
+   * The response data includes the serialized form of the thrown exception.
+   */
+  E_INVOKE(true),
+
+  /**
+   * Response error: an exception ocurred when serializing the response.
+   * The response data includes the serialized form of the thrown exception.
+   */
+  E_MARSHAL(true),
+
+  /**
+   * Response error: an exception ocurred when deserializing the request arguments.
+   * The response data includes the serialized form of the thrown exception.
+   */
+  E_UNMARSHAL(true),
+
+  /**
+   * Response error: unlisted exception.
+   * The response data includes the serialized form of the thrown exception.
+   */
+  E_UNKNOWN(true);
+
+  @Getter
+  @Accessors(fluent = true)
+  private final boolean hasException;
+}

--- a/src/main/java/com/flowingcode/vaadin/testbench/rpc/RpcException.java
+++ b/src/main/java/com/flowingcode/vaadin/testbench/rpc/RpcException.java
@@ -37,6 +37,10 @@ public class RpcException extends RuntimeException {
     super(makeMessage(method, arguments, cause.getMessage()), cause);
   }
 
+  public RpcException(String method, Object[] arguments, String message, Throwable cause) {
+    super(makeMessage(method, arguments, message), cause);
+  }
+
   private static String makeMessage(String method, Object[] arguments, String message) {
     return String.format(
         "%s(%s) RPC call failed%s",

--- a/src/test/java/com/flowingcode/vaadin/testbench/rpc/RmiErrorTest.java
+++ b/src/test/java/com/flowingcode/vaadin/testbench/rpc/RmiErrorTest.java
@@ -1,0 +1,317 @@
+/*-
+ * #%L
+ * RPC for Vaadin TestBench
+ * %%
+ * Copyright (C) 2021 - 2023 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.flowingcode.vaadin.testbench.rpc;
+
+import static com.flowingcode.vaadin.testbench.rpc.RmiConstants.RMI_CLASS_NAME;
+import static com.flowingcode.vaadin.testbench.rpc.RmiConstants.RMI_INSTANCE_ID;
+import static com.flowingcode.vaadin.testbench.rpc.RmiConstants.RMI_METHOD_ARGUMENTS;
+import static com.flowingcode.vaadin.testbench.rpc.RmiConstants.RMI_METHOD_NAME;
+import static com.flowingcode.vaadin.testbench.rpc.RmiConstants.RMI_METHOD_SIGNATURE;
+import static com.flowingcode.vaadin.testbench.rpc.RmiConstants.RMI_RESPONSE_DATA;
+import static com.flowingcode.vaadin.testbench.rpc.RmiConstants.RMI_RESPONSE_ERROR;
+import static com.flowingcode.vaadin.testbench.rpc.RmiConstants.RMI_RESPONSE_MARKER;
+import static org.hamcrest.MatcherAssert.assertThat;
+import com.vaadin.flow.component.html.Div;
+import elemental.json.Json;
+import elemental.json.JsonArray;
+import elemental.json.JsonNull;
+import elemental.json.JsonObject;
+import elemental.json.JsonType;
+import elemental.json.JsonValue;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.lang.reflect.UndeclaredThrowableException;
+import java.util.Base64;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.With;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+@SuppressWarnings("serial")
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class RmiErrorTest {
+
+
+  @SuppressWarnings("unused")
+  private static class RmiCallableTest extends Div implements RmiCallable {
+    public RmiRemote method() {
+      return null;
+    }
+
+    public void throwException() {
+      throw new RuntimeException();
+    }
+
+    public void throwError() {
+      throw new Error();
+    }
+
+    public void methodWithArguments(Serializable args) {
+
+    }
+
+    public Serializable marshalError() {
+      return new Serializable() {
+        Object notSerializable = new Object() {};
+      };
+    }
+  }
+
+  private Matcher<JsonValue> hasMarker() {
+    return new JsonObjectMatcher(RMI_RESPONSE_MARKER, RmiCallable.class.getName());
+  }
+
+  private Matcher<JsonValue> hasError(RmiError error) {
+    return new JsonObjectMatcher(RMI_RESPONSE_ERROR, error.name()) {
+
+      @Override
+      public void describeTo(Description description) {
+        super.describeTo(description);
+        if (error.hasException()) {
+          description.appendText(" with exception data");
+        } else {
+          description.appendText(" with no exception data");
+        }
+      }
+
+      @Override
+      protected boolean matchesSafely(JsonValue item, Description mismatchDescription) {
+        if (super.matchesSafely(item, mismatchDescription)) {
+          JsonObject obj = (JsonObject) item;
+          if (!error.hasException() && obj.hasKey(RMI_RESPONSE_DATA)) {
+            mismatchDescription.appendText(" with exception data");
+            return false;
+          }
+          if (error.hasException() && !obj.hasKey(RMI_RESPONSE_DATA)) {
+            mismatchDescription.appendText(" with no exception data");
+            return false;
+          }
+          if (error.hasException()) {
+            String data = ((JsonObject) item).getString(RMI_RESPONSE_DATA);
+            try {
+              ObjectInputStream ois =
+                  new ObjectInputStream(new ByteArrayInputStream(Base64.getDecoder().decode(data)));
+              Class<?> clazz = ois.readObject().getClass();
+              if (Throwable.class.isAssignableFrom(clazz)) {
+                return true;
+              } else {
+                mismatchDescription.appendText("data is " + clazz.getName());
+                return false;
+              }
+            } catch (Exception e) {
+              throw new RuntimeException(e);
+            }
+          }
+          return true;
+        } else {
+          return false;
+        }
+      }
+    };
+  }
+
+  @With
+  @AllArgsConstructor
+  @NoArgsConstructor
+  private static class Request {
+    String instanceId;
+    String className;
+    String methodName;
+    String[] methodSignature;
+    Object[] methodArguments;
+    String rawMethodArguments;
+
+    JsonValue call() {
+      JsonObject obj = Json.createObject();
+      if (instanceId != null) {
+        obj.put(RMI_INSTANCE_ID, instanceId);
+      }
+      if (className != null) {
+        obj.put(RMI_CLASS_NAME, className);
+      }
+
+      if (methodName == null) {
+        methodName = "method";
+      }
+      obj.put(RMI_METHOD_NAME, methodName);
+
+      if (methodSignature == null) {
+        methodSignature = new String[0];
+      }
+
+      JsonArray signatureArray = Json.createArray();
+      obj.put(RMI_METHOD_SIGNATURE, signatureArray);
+      for (String s : methodSignature) {
+        signatureArray.set(signatureArray.length(), s);
+      }
+
+      if (rawMethodArguments != null) {
+        obj.put(RMI_METHOD_ARGUMENTS, rawMethodArguments);
+      } else if (methodArguments != null) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+          oos.writeObject(methodArguments);
+        } catch (IOException e) {
+          throw new UndeclaredThrowableException(e);
+        }
+        obj.put(RMI_METHOD_ARGUMENTS, Base64.getEncoder().encodeToString(baos.toByteArray()));
+      }
+
+
+      return new RmiCallableTest() {}.$call(obj);
+    }
+  }
+
+  private static class JsonObjectMatcher extends TypeSafeDiagnosingMatcher<JsonValue> {
+
+    private final String key;
+    private final String value;
+
+    public JsonObjectMatcher(String key, String value) {
+      super(JsonObject.class);
+      this.key = key;
+      this.value = value;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+      if (value == null) {
+        description.appendText(String.format("%s is %s", key, JsonType.STRING));
+      } else {
+        description.appendText(String.format("%s is '%s'", key, value));
+      }
+    }
+
+    @Override
+    protected boolean matchesSafely(JsonValue item, Description mismatchDescription) {
+      JsonObject obj = (JsonObject) item;
+      if (!obj.hasKey(key)) {
+        mismatchDescription.appendText("no " + key);
+        return false;
+      }
+      JsonType type = obj.get(key).getType();
+      if (type != JsonType.STRING) {
+        mismatchDescription.appendText(key + " is " + type);
+        return false;
+      }
+      if (value != null && !obj.getString(key).equals(value)) {
+        mismatchDescription.appendText(String.format("%s is '%s'", key, obj.getString(key)));
+        return false;
+      }
+      return true;
+    }
+  };
+
+  @Test
+  public void test01_ProtocolSuccess() {
+    JsonValue response = new Request().call();
+    assertThat(response, Matchers.instanceOf(JsonNull.class));
+  }
+
+  @Test
+  public void test02_ProtocolErrorNoClass() {
+    JsonValue response = new Request().withInstanceId("inst").call();
+    assertThat(response, hasMarker());
+    assertThat(response, hasError(RmiError.E_PROTOCOL_ERROR));
+  }
+
+  @Test
+  public void test02_ProtocolErrorNoId() {
+    JsonValue response = new Request().withClassName("clazz").call();
+    assertThat(response, hasMarker());
+    assertThat(response, hasError(RmiError.E_PROTOCOL_ERROR));
+  }
+
+  @Test
+  public void test03_ClassNotFound() {
+    JsonValue response = new Request().withInstanceId("foo").withClassName("clazz").call();
+    assertThat(response, hasMarker());
+    assertThat(response, hasError(RmiError.E_CLASS_NOT_FOUND));
+  }
+
+  @Test
+  public void test04_NoSuchMethod() {
+    JsonValue response = new Request().withMethodName("noSuchMethod").call();
+    assertThat(response, hasMarker());
+    assertThat(response, hasError(RmiError.E_NO_SUCH_METHOD));
+  }
+
+  @Test
+  public void test05_Unmarshall_NotInBase64() {
+    JsonValue response = new Request()
+        .withMethodName("methodWithArguments")
+        .withMethodSignature(new String[] {"java.io.Serializable"})
+        .withRawMethodArguments("@").call();
+    assertThat(response, hasMarker());
+    assertThat(response, hasError(RmiError.E_UNMARSHAL));
+  }
+
+  @Test
+  public void test05_Unmarshall_DeserializationError() {
+    JsonValue response = new Request().withMethodName("methodWithArguments")
+        .withMethodSignature(new String[] {"java.io.Serializable"})
+        .withRawMethodArguments(Base64.getEncoder().encodeToString(new byte[0])).call();
+    assertThat(response, hasMarker());
+    assertThat(response, hasError(RmiError.E_UNMARSHAL));
+  }
+
+  @Test
+  public void test06_Invoke_Exception() {
+    JsonValue response = new Request().withMethodName("throwException").call();
+    assertThat(response, hasMarker());
+    assertThat(response, hasError(RmiError.E_INVOKE));
+  }
+
+  @Test
+  public void test06_Invoke_Error() {
+    JsonValue response = new Request().withMethodName("throwError").call();
+    assertThat(response, hasMarker());
+    assertThat(response, hasError(RmiError.E_INVOKE));
+  }
+
+  @Test
+  public void test07_ObjectNotExists() {
+    JsonValue response = new Request()
+        .withInstanceId("foo")
+        .withMethodName("toString")
+        .withClassName(Object.class.getName())
+        .call();
+    assertThat(response, hasMarker());
+    assertThat(response, hasError(RmiError.E_OBJECT_NOT_EXIST));
+  }
+
+  @Test
+  public void test08_Marshall() {
+    JsonValue response = new Request().withMethodName("marshalError").call();
+    assertThat(response, hasMarker());
+    assertThat(response, hasError(RmiError.E_MARSHAL));
+  }
+
+}

--- a/src/test/java/com/flowingcode/vaadin/testbench/rpc/integration/RmiIntegrationView.java
+++ b/src/test/java/com/flowingcode/vaadin/testbench/rpc/integration/RmiIntegrationView.java
@@ -58,6 +58,11 @@ public class RmiIntegrationView extends Div implements RmiIntegrationViewCallabl
   }
 
   @Override
+  public JsonObject testFailureJsonObject() {
+    throw new RuntimeException();
+  }
+
+  @Override
   @ClientCallable
   public JsonValue $call(JsonObject invocation) {
     return RmiIntegrationViewCallables.super.$call(invocation);

--- a/src/test/java/com/flowingcode/vaadin/testbench/rpc/integration/RmiIntegrationView.java
+++ b/src/test/java/com/flowingcode/vaadin/testbench/rpc/integration/RmiIntegrationView.java
@@ -24,6 +24,7 @@ import com.vaadin.flow.component.ClientCallable;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.router.Route;
+import elemental.json.Json;
 import elemental.json.JsonObject;
 import elemental.json.JsonValue;
 import java.io.Serializable;
@@ -142,4 +143,10 @@ public class RmiIntegrationView extends Div implements RmiIntegrationViewCallabl
     return new Wrapper<>(getCounter(name));
   }
 
+  @Override
+  public JsonObject returnJsonObject(String key, String value) {
+    JsonObject obj = Json.createObject();
+    obj.put(key, value);
+    return obj;
+  }
 }

--- a/src/test/java/com/flowingcode/vaadin/testbench/rpc/integration/RmiIntegrationViewCallables.java
+++ b/src/test/java/com/flowingcode/vaadin/testbench/rpc/integration/RmiIntegrationViewCallables.java
@@ -33,6 +33,8 @@ public interface RmiIntegrationViewCallables extends RmiCallable {
 
   void testCallableFailure();
 
+  JsonObject testFailureJsonObject();
+
   long testLong(long arg);
 
   interface AnotherInterface {

--- a/src/test/java/com/flowingcode/vaadin/testbench/rpc/integration/RmiIntegrationViewCallables.java
+++ b/src/test/java/com/flowingcode/vaadin/testbench/rpc/integration/RmiIntegrationViewCallables.java
@@ -22,6 +22,7 @@ package com.flowingcode.vaadin.testbench.rpc.integration;
 import com.flowingcode.vaadin.testbench.rpc.RmiCallable;
 import com.flowingcode.vaadin.testbench.rpc.RmiRemote;
 import com.vaadin.flow.component.Component;
+import elemental.json.JsonObject;
 import java.io.Serializable;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -77,5 +78,7 @@ public interface RmiIntegrationViewCallables extends RmiCallable {
   <T extends RmiRemote> Wrapper<T> wrap(T remote);
 
   Wrapper<ICounter> createWrappedCounter(String name);
+
+  JsonObject returnJsonObject(String key, String value);
 
 }

--- a/src/test/java/com/flowingcode/vaadin/testbench/rpc/integration/RmiIntegrationViewIT.java
+++ b/src/test/java/com/flowingcode/vaadin/testbench/rpc/integration/RmiIntegrationViewIT.java
@@ -26,6 +26,7 @@ import com.flowingcode.vaadin.testbench.rpc.RpcException;
 import com.flowingcode.vaadin.testbench.rpc.integration.RmiIntegrationViewCallables.ICounter;
 import com.flowingcode.vaadin.testbench.rpc.integration.RmiIntegrationViewCallables.Identity;
 import com.flowingcode.vaadin.testbench.rpc.integration.RmiIntegrationViewCallables.MyRemoteObject;
+import elemental.json.JsonObject;
 import java.io.Serializable;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Assert;
@@ -151,6 +152,14 @@ public class RmiIntegrationViewIT extends AbstractViewTest implements HasRpcSupp
   public void test10_testLong() {
     // test passing and returning a primitive long
     Assert.assertEquals(42L, $server.testLong(42));
+  }
+
+  @Test
+  public void test10_testJsonObject() {
+    // test passing and returning a JsonObject
+    String k = "key", v = "hello";
+    JsonObject obj = $server.returnJsonObject(k, v);
+    Assert.assertEquals(v, obj.getString(k));
   }
 
   @Test


### PR DESCRIPTION
Improve RMI error reporting by returning a `RMI_RESPONSE_ERROR` property that communicates back to the test-side what went wrong in the server-side (along with the remote exception trace, so that one doesn't have to "check the server logs", and all the failure is captured in JUnit output). There are different error codes that distinguish internal RMI errors (serialization, reflection, etc) from actual exceptions thrown by the invoked methods. 

- E_PROTOCOL_ERROR: indicates that the request was incorrectly formatted.
- E_CLASS_NOT_FOUND: indicates that the requested target class could not be located.
- E_NO_SUCH_METHOD: indicates that the target class does not implement the requested method.
- E_OBJECT_NOT_EXIST: indicates an attempt to pass an unregistered value as an object reference.
- E_INVOKE: represents an exception that occurred when executing a remote method. The response data includes the serialized form of the thrown exception.
- E_MARSHAL: indicates an error that occurred when serializing the response. The response data includes the serialized form of the thrown exception.
- E_UNMARSHAL: indicates an error that occurred when deserializing the request arguments. The response data includes the serialized form of the thrown exception.
- E_UNKNOWN: represents an unlisted exception. The response data includes the serialized form of the thrown exception.