### PR TITLE
Refactor: remove redundante code

### DIFF
--- a/src/main/java/com/flowingcode/vaadin/testbench/rpc/RmiCallable.java
+++ b/src/main/java/com/flowingcode/vaadin/testbench/rpc/RmiCallable.java
@@ -172,11 +172,6 @@ public interface RmiCallable {
         return JsonCodec.encodeWithTypeInfo(result);
       }
 
-      if (result instanceof RmiRemote) {
-        String resultId = registry.register((RmiRemote) result);
-        result = registry.lookup(resultId);
-      }
-
       try {
         return RmiCallable$companion.createResponse(registry, result);
       } catch (ObjectStreamException e) {


### PR DESCRIPTION
There is no need to register the result because serialization in `createResponse` will take care of that.

https://github.com/FlowingCode/testbench-rpc/blob/bdba17dd86677f8604d3a9ee52f55250bfd1938b/src/main/java/com/flowingcode/vaadin/testbench/rpc/RmiCallable.java#L213-L216
