### PR TITLE
Fixes for RPC/RMI compatibility

### DIFF
--- a/src/main/java/com/flowingcode/vaadin/testbench/rpc/HasRpcSupport.java
+++ b/src/main/java/com/flowingcode/vaadin/testbench/rpc/HasRpcSupport.java
@@ -364,6 +364,10 @@ class HasRpcSupport$RmiInvocationHandler extends HasRpcSupport$InvocationHandler
       }
     }
 
+    if (returnType == JsonArrayList.class) {
+      return TypeConversion.castList((List<?>) result, method.getGenericReturnType());
+    }
+
     return TypeConversion.cast(result, returnType);
   }
 

--- a/src/main/java/com/flowingcode/vaadin/testbench/rpc/RmiCallable.java
+++ b/src/main/java/com/flowingcode/vaadin/testbench/rpc/RmiCallable.java
@@ -169,7 +169,7 @@ public interface RmiCallable {
       }
 
       if (result == null || JsonCodec.canEncodeWithoutTypeInfo(result.getClass())) {
-        return JsonCodec.encodeWithTypeInfo(result);
+        return JsonCodec.encodeWithoutTypeInfo(result);
       }
 
       try {

--- a/src/test/java/com/flowingcode/vaadin/testbench/rpc/integration/IntegrationViewIT.java
+++ b/src/test/java/com/flowingcode/vaadin/testbench/rpc/integration/IntegrationViewIT.java
@@ -53,6 +53,10 @@ public class IntegrationViewIT extends AbstractViewTest implements HasRpcSupport
     super(IntegrationView.ROUTE);
   }
 
+  protected IntegrationViewIT(String route) {
+    super(route);
+  }
+
   IntegrationViewCallables $server = createCallableProxy(IntegrationViewCallables.class);
 
   @Test

--- a/src/test/java/com/flowingcode/vaadin/testbench/rpc/integration/IntegrationViewRmi.java
+++ b/src/test/java/com/flowingcode/vaadin/testbench/rpc/integration/IntegrationViewRmi.java
@@ -1,0 +1,43 @@
+/*-
+ * #%L
+ * RPC for Vaadin TestBench
+ * %%
+ * Copyright (C) 2021 - 2023 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.flowingcode.vaadin.testbench.rpc.integration;
+
+import com.vaadin.flow.component.ClientCallable;
+import com.vaadin.flow.router.Route;
+import elemental.json.JsonObject;
+import elemental.json.JsonValue;
+
+@SuppressWarnings("serial")
+@Route(IntegrationViewRmi.ROUTE)
+public class IntegrationViewRmi extends IntegrationView implements IntegrationViewRmiCallables {
+
+  public static final String ROUTE = "it/rmi2";
+
+  public IntegrationViewRmi() {
+    setId("view");
+  }
+
+  @Override
+  @ClientCallable
+  public JsonValue $call(JsonObject invocation) {
+    return IntegrationViewRmiCallables.super.$call(invocation);
+  }
+
+}

--- a/src/test/java/com/flowingcode/vaadin/testbench/rpc/integration/IntegrationViewRmiCallables.java
+++ b/src/test/java/com/flowingcode/vaadin/testbench/rpc/integration/IntegrationViewRmiCallables.java
@@ -1,0 +1,7 @@
+package com.flowingcode.vaadin.testbench.rpc.integration;
+
+import com.flowingcode.vaadin.testbench.rpc.RmiCallable;
+
+public interface IntegrationViewRmiCallables extends IntegrationViewCallables, RmiCallable {
+
+}

--- a/src/test/java/com/flowingcode/vaadin/testbench/rpc/integration/IntegrationViewRmiIT.java
+++ b/src/test/java/com/flowingcode/vaadin/testbench/rpc/integration/IntegrationViewRmiIT.java
@@ -1,0 +1,37 @@
+/*-
+ * #%L
+ * RPC for Vaadin TestBench
+ * %%
+ * Copyright (C) 2021 - 2023 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.flowingcode.vaadin.testbench.rpc.integration;
+
+import org.junit.FixMethodOrder;
+import org.junit.runners.MethodSorters;
+
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class IntegrationViewRmiIT extends IntegrationViewIT {
+
+  public IntegrationViewRmiIT() {
+    super(IntegrationViewRmi.ROUTE);
+  }
+
+  {
+    $server = createCallableProxy(IntegrationViewRmiCallables.class);
+  }
+
+}


### PR DESCRIPTION
This PR addresses two issues encountered while retrofitting a callable interface to incorporate RMI support.

- fixes an issue that occurs when returning a `JsonArray`, encoding the result without including type information. 
- fixes an issue where a `JsonArrayList` cannot be returned when using RMI, ensuring proper handling of JsonArrayList in RMI calls. 

These changes aim to improve the compatibility of the codebase when integrating RMI capabilities into existing callable interfaces.