### PR TITLE
build: attach sources and javadoc in package phase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -246,7 +246,7 @@
                 <executions>
                     <execution>
                         <id>attach-sources</id>
-                        <phase>verify</phase>
+                        <phase>package</phase>
                         <goals>
                             <goal>jar-no-fork</goal>
                         </goals>
@@ -260,7 +260,7 @@
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
-                        <phase>verify</phase>
+                        <phase>package</phase>
                         <goals>
                             <goal>jar</goal>
                         </goals>


### PR DESCRIPTION
TL;DR attach sources and javadoc in _package_ phase instead of _verify_.

In order to sign deployed files with GPG/PGP (https://github.com/FlowingCode/AddonsDemo/issues/160) I need to run `gpg:sign` after sources and javadocs have been attached. However, "goals order in a phase can't be defined in a flexible way" [[MNG-7804](https://issues.apache.org/jira/browse/MNG-7804)] and it happens that both sources and javadocs are attached at the _verify_ phase (following the example given in the [plugin's documentation](https://maven.apache.org/plugins/maven-source-plugin/usage.html#installing-the-sources-using-a-phase-binding)).

That example mentions that "we are using the verify phase here because it is the phase that comes before the install phase, thus making sure that the sources jar has been created before the install takes place." However, considering the [maven lifecycle](https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html#default-lifecycle), "any operations necessary to prepare a package before the actual packaging" take place in _prepare-package_, thus we can assume that all the resources are in their final form when the _package_ phase executes, and we don't need to wait until `verify` in order to attach sources and javadocs.

I've just built this branch in our CI environment and with this change `clean package gpg:sign deploy` is able to sign all the deployed files.