### PR TITLE
ci: add GPG settings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,10 +107,10 @@
             <version>${vaadin.version}</version>             
             <scope>test</scope>
             <exclusions>
-            	<exclusion>
-            		<groupId>org.webjars.bowergithub.polymer</groupId>
-            		<artifactId>polymer</artifactId>
-            	</exclusion>
+                <exclusion>
+                    <groupId>org.webjars.bowergithub.polymer</groupId>
+                    <artifactId>polymer</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
             
@@ -414,6 +414,33 @@
                 </pluginManagement>
             </build>
         </profile>
-                
+
+        <profile>
+            <id>gpg</id>
+            <activation>
+                <property>
+                    <name>gpg.passphrase</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>3.1.0</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
     </profiles>
 </project>


### PR DESCRIPTION
Plugins cannot be _added_ in external settings.xml files. The external configuration was ignored (gpg:sign did never bind to the verify phase) but it ran because I had changed the goals to `clean package gpg:sign deploy`. 

In order to integrate with the release plugin, I think it's better that we define a profile with implicit activation (if the GPG passphrase is provided), so that the goal is just `clean deploy` using default settings.xml.