### PR TITLE
feat: add side channel support

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,3 +220,22 @@ public class SampleView extends Div implements SampleCallables {
     assertEquals("foo", remote.getName());
   }
 ```  
+
+## Side-channel Invocation
+
+Side-channel invocation allows invoking methods (either by using RMI or client-callable RPC) from another view. 
+This feature is useful in cases where you want to expose methods from reusable views.
+
+In order to support side-channel invocations:
+
+1. Initialize the proxy by providing a URL. The url will be opened in a second tab, and calls to server methods will be dispatched from that tab. TestbenchRPC takes care of switching back to the original tab when the call completes. 
+```
+OtherCallables $server = createCallableProxy(OtherCallables.class, getURL("other"));
+```
+
+2. Optionally, implement `SideChannelSupport` in the callable interface. This interface adds a `closeSideChannel()` method to the proxy, which allows closing the side tab.
+```
+public interface OtherCallables extends SideChannelSupport { ... }
+```
+
+When using RMI, remember that stubs are UI-scoped. Closing the side channel will invalidate all of its stubs.

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.flowingcode.vaadin.test</groupId>
     <artifactId>testbench-rpc</artifactId>
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
     <name>TestBenchRPC</name>
     <description>Remote procedure calls for Vaadin TestBench</description>
     <url>https://www.flowingcode.com/en/open-source/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>4.3.1</version>
+            <version>5.5.2</version>
             <scope>test</scope>
         </dependency>        
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <url>https://www.flowingcode.com/en/open-source/</url>
 
     <properties>
-        <vaadin.version>14.10.1</vaadin.version>
+        <vaadin.version>14.10.6</vaadin.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/com/flowingcode/vaadin/testbench/rpc/HasRpcSupport.java
+++ b/src/main/java/com/flowingcode/vaadin/testbench/rpc/HasRpcSupport.java
@@ -248,10 +248,13 @@ abstract class HasRpcSupport$InvocationHandler implements InvocationHandler {
 }
 
 
-@RequiredArgsConstructor
 final class HasRpcSupport$SimpleInvocationHandler extends HasRpcSupport$InvocationHandler {
 
   private final HasRpcSupport rpc;
+
+  public HasRpcSupport$SimpleInvocationHandler(HasRpcSupport rpc) {
+    this.rpc = rpc;
+  }
 
   @Override
   Object dispatch(Method method, Object[] args) throws RpcCallException {
@@ -273,12 +276,18 @@ final class HasRpcSupport$SimpleInvocationHandler extends HasRpcSupport$Invocati
 }
 
 
-@RequiredArgsConstructor
 class HasRpcSupport$RmiInvocationHandler extends HasRpcSupport$InvocationHandler {
 
   private final HasRpcSupport rpc;
   private final Class<?>[] interfaces;
   private final String instanceId;
+
+  public HasRpcSupport$RmiInvocationHandler(HasRpcSupport rpc, Class<?>[] interfaces,
+      String instanceId) {
+    this.rpc = rpc;
+    this.interfaces = interfaces;
+    this.instanceId = instanceId;
+  }
 
   @Override
   Object dispatch(Method method, Object[] args) throws IOException, RpcCallException {

--- a/src/main/java/com/flowingcode/vaadin/testbench/rpc/RmiRemoteReplacement.java
+++ b/src/main/java/com/flowingcode/vaadin/testbench/rpc/RmiRemoteReplacement.java
@@ -45,12 +45,12 @@ final class RmiRemoteReplacement implements Serializable {
         .filter(RmiRemote.class::isAssignableFrom).toArray(Class<?>[]::new);
   }
 
-  Object createStub(@NonNull HasRpcSupport rpc) {
+  Object createStub(@NonNull HasRpcSupport rpc, String sideChannelUrl) {
     Class<?>[] interfaces = this.interfaces;
     interfaces = Arrays.copyOf(interfaces, interfaces.length + 1);
     interfaces[interfaces.length - 1] = RmiStub.class;
 
-    return HasRpcSupport$companion.createCallableProxy(rpc, interfaces, instanceId);
+    return HasRpcSupport$companion.createCallableProxy(rpc, interfaces, instanceId, sideChannelUrl);
   }
 
 }

--- a/src/main/java/com/flowingcode/vaadin/testbench/rpc/SideChannelSupport.java
+++ b/src/main/java/com/flowingcode/vaadin/testbench/rpc/SideChannelSupport.java
@@ -1,0 +1,9 @@
+package com.flowingcode.vaadin.testbench.rpc;
+
+public interface SideChannelSupport {
+
+  default void closeSideChannel() {
+    throw new UnsupportedOperationException();
+  }
+
+}

--- a/src/test/java/com/flowingcode/vaadin/testbench/rpc/AbstractViewTest.java
+++ b/src/test/java/com/flowingcode/vaadin/testbench/rpc/AbstractViewTest.java
@@ -98,7 +98,7 @@ public abstract class AbstractViewTest extends ParallelTest {
    *
    * @return URL to route
    */
-  private static String getURL(String route) {
+  protected static String getURL(String route) {
     return String.format("http://%s:%d/%s", getDeploymentHostname(), SERVER_PORT, route);
   }
 

--- a/src/test/java/com/flowingcode/vaadin/testbench/rpc/integration/IntegrationViewCallables.java
+++ b/src/test/java/com/flowingcode/vaadin/testbench/rpc/integration/IntegrationViewCallables.java
@@ -20,6 +20,7 @@
 package com.flowingcode.vaadin.testbench.rpc.integration;
 
 import com.flowingcode.vaadin.testbench.rpc.JsonArrayList;
+import com.flowingcode.vaadin.testbench.rpc.SideChannelSupport;
 import elemental.json.JsonArray;
 import elemental.json.JsonBoolean;
 import elemental.json.JsonNull;
@@ -28,7 +29,7 @@ import elemental.json.JsonObject;
 import elemental.json.JsonString;
 import elemental.json.JsonValue;
 
-public interface IntegrationViewCallables {
+public interface IntegrationViewCallables extends SideChannelSupport {
 
   void testCallableFailure();
 

--- a/src/test/java/com/flowingcode/vaadin/testbench/rpc/integration/OtherView.java
+++ b/src/test/java/com/flowingcode/vaadin/testbench/rpc/integration/OtherView.java
@@ -1,0 +1,31 @@
+/*-
+ * #%L
+ * RPC for Vaadin TestBench
+ * %%
+ * Copyright (C) 2021 - 2023 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.flowingcode.vaadin.testbench.rpc.integration;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+
+@SuppressWarnings("serial")
+@Route(OtherView.ROUTE)
+public class OtherView extends Div {
+
+  public static final String ROUTE = "it/other";
+
+}

--- a/src/test/java/com/flowingcode/vaadin/testbench/rpc/integration/RmiIntegrationViewCallables.java
+++ b/src/test/java/com/flowingcode/vaadin/testbench/rpc/integration/RmiIntegrationViewCallables.java
@@ -21,13 +21,14 @@ package com.flowingcode.vaadin.testbench.rpc.integration;
 
 import com.flowingcode.vaadin.testbench.rpc.RmiCallable;
 import com.flowingcode.vaadin.testbench.rpc.RmiRemote;
+import com.flowingcode.vaadin.testbench.rpc.SideChannelSupport;
 import com.vaadin.flow.component.Component;
 import elemental.json.JsonObject;
 import java.io.Serializable;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
-public interface RmiIntegrationViewCallables extends RmiCallable {
+public interface RmiIntegrationViewCallables extends RmiCallable, SideChannelSupport {
 
   void testCallableSuccess();
 

--- a/src/test/java/com/flowingcode/vaadin/testbench/rpc/integration/SideIntegrationViewIT.java
+++ b/src/test/java/com/flowingcode/vaadin/testbench/rpc/integration/SideIntegrationViewIT.java
@@ -1,0 +1,46 @@
+package com.flowingcode.vaadin.testbench.rpc.integration;
+
+import static org.junit.Assert.assertEquals;
+import com.flowingcode.vaadin.testbench.rpc.AbstractViewTest;
+import com.flowingcode.vaadin.testbench.rpc.HasRpcSupport;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class SideIntegrationViewIT extends AbstractViewTest implements HasRpcSupport {
+
+  public SideIntegrationViewIT() {
+    super(OtherView.ROUTE);
+  }
+
+  IntegrationViewCallables $server =
+      createCallableProxy(IntegrationViewCallables.class, getURL(IntegrationView.ROUTE));
+
+  @Test
+  public void test01_callable() {
+    $server.testCallableSuccess();
+    assertEquals(2, getDriver().getWindowHandles().size());
+  }
+
+  @Test
+  public void test02_reuse() {
+    $server.testCallableSuccess();
+    $server.testCallableSuccess();
+  }
+
+  @Test
+  public void test03_close() {
+    $server.testCallableSuccess();
+    $server.closeSideChannel();
+    assertEquals(1, getDriver().getWindowHandles().size());
+  }
+
+  @Test
+  public void test04_reopen() {
+    $server.testCallableSuccess();
+    $server.closeSideChannel();
+    $server.testCallableSuccess();
+    assertEquals(2, getDriver().getWindowHandles().size());
+  }
+}

--- a/src/test/java/com/flowingcode/vaadin/testbench/rpc/integration/SideRmiIntegrationViewIT.java
+++ b/src/test/java/com/flowingcode/vaadin/testbench/rpc/integration/SideRmiIntegrationViewIT.java
@@ -1,0 +1,47 @@
+package com.flowingcode.vaadin.testbench.rpc.integration;
+
+import static org.junit.Assert.assertEquals;
+import com.flowingcode.vaadin.testbench.rpc.AbstractViewTest;
+import com.flowingcode.vaadin.testbench.rpc.HasRpcSupport;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class SideRmiIntegrationViewIT extends AbstractViewTest implements HasRpcSupport {
+
+  public SideRmiIntegrationViewIT() {
+    super(OtherView.ROUTE);
+  }
+
+  RmiIntegrationViewCallables $server =
+      createCallableProxy(RmiIntegrationViewCallables.class, getURL(RmiIntegrationView.ROUTE));
+
+  @Test
+  public void test01_callable() {
+    $server.testCallableSuccess();
+    assertEquals(2, getDriver().getWindowHandles().size());
+  }
+
+  @Test
+  public void test02_reuse() {
+    $server.testCallableSuccess();
+    $server.testCallableSuccess();
+  }
+
+  @Test
+  public void test03_close() {
+    $server.testCallableSuccess();
+    $server.closeSideChannel();
+    assertEquals(1, getDriver().getWindowHandles().size());
+  }
+
+  @Test
+  public void test04_reopen() {
+    $server.testCallableSuccess();
+    $server.closeSideChannel();
+    $server.testCallableSuccess();
+    assertEquals(2, getDriver().getWindowHandles().size());
+  }
+
+}

--- a/src/test/java/com/flowingcode/vaadin/testbench/rpc/sample/OtherCallables.java
+++ b/src/test/java/com/flowingcode/vaadin/testbench/rpc/sample/OtherCallables.java
@@ -1,0 +1,26 @@
+/*-
+ * #%L
+ * RPC for Vaadin TestBench
+ * %%
+ * Copyright (C) 2021 - 2023 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.flowingcode.vaadin.testbench.rpc.sample;
+
+public interface OtherCallables {
+
+  String getClassName();
+
+}

--- a/src/test/java/com/flowingcode/vaadin/testbench/rpc/sample/OtherIT.java
+++ b/src/test/java/com/flowingcode/vaadin/testbench/rpc/sample/OtherIT.java
@@ -1,0 +1,41 @@
+/*-
+ * #%L
+ * RPC for Vaadin TestBench
+ * %%
+ * Copyright (C) 2021 - 2023 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.flowingcode.vaadin.testbench.rpc.sample;
+
+import static org.junit.Assert.assertEquals;
+import com.flowingcode.vaadin.testbench.rpc.AbstractViewTest;
+import com.flowingcode.vaadin.testbench.rpc.HasRpcSupport;
+import org.junit.Test;
+
+public class OtherIT extends AbstractViewTest implements HasRpcSupport {
+  // this test opens "" but calls a method in "other"
+
+  public OtherIT() {
+    super("");
+  }
+
+  OtherCallables $server = createCallableProxy(OtherCallables.class, getURL("other"));
+
+  @Test
+  public void testNotification() {
+    assertEquals(OtherView.class.getName(), $server.getClassName());
+  }
+
+}

--- a/src/test/java/com/flowingcode/vaadin/testbench/rpc/sample/OtherView.java
+++ b/src/test/java/com/flowingcode/vaadin/testbench/rpc/sample/OtherView.java
@@ -1,0 +1,35 @@
+/*-
+ * #%L
+ * RPC for Vaadin TestBench
+ * %%
+ * Copyright (C) 2021 - 2023 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.flowingcode.vaadin.testbench.rpc.sample;
+
+import com.vaadin.flow.component.ClientCallable;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+
+@Route("other")
+public class OtherView extends Div implements OtherCallables {
+
+  @Override
+  @ClientCallable
+  public String getClassName() {
+    return this.getClass().getName();
+  }
+
+}

--- a/src/test/java/com/flowingcode/vaadin/testbench/rpc/sample/SideChannel.java
+++ b/src/test/java/com/flowingcode/vaadin/testbench/rpc/sample/SideChannel.java
@@ -1,0 +1,7 @@
+package com.flowingcode.vaadin.testbench.rpc.sample;
+
+public interface SideChannel<T> {
+
+  T on(String route);
+
+}


### PR DESCRIPTION
Side-channel invocation allows invoking methods (either by using RMI or client-callable RPC) from another view. 
This feature is useful in cases where you want to expose methods from reusable views.